### PR TITLE
Comment out MULTIPART_UNMATCHED_BOUNDARY rule since it causes false p…

### DIFF
--- a/templates/modsecurity.conf.j2
+++ b/templates/modsecurity.conf.j2
@@ -80,8 +80,8 @@ FL %{MULTIPART_FILE_LIMIT_EXCEEDED}'"
 
 # Did we see anything that might be a boundary?
 #
-SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
-"id:'200004',phase:2,t:none,log,deny,msg:'Multipart parser detected a possible unmatched boundary.'"
+#SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
+#"id:'200004',phase:2,t:none,log,deny,msg:'Multipart parser detected a possible unmatched boundary.'"
 
 # PCRE Tuning
 # We want to avoid a potential RegEx DoS condition


### PR DESCRIPTION
Hey!
Die uncommented SecRule verursacht false positives beim Upload von Dateien via Share-Link in Seafile. 
Das Internet scheint sich einig zu sein, dass dies ohnehin eine problematische Rule ist, die von den meisten ModSec usern deaktiviert wird.

Hoffe ihr zieht eine Änderung in Erwägung. :)

Wenn nicht, muss ich meine Teammitglieder auf euch hetzen!

Liebe Grüße
Sascha Windisch vom heiCLOUD Team