### PR TITLE
Make ModSecurity and CRS configurable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,6 @@ Thomas Kaeseberg
 Olaf Pichler
 Caner Topuz
 Stefan Machmeier
+Horst Schneider
+Marc Brendel
+Sascha Windisch

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 crs_dir: "/opt/owasp_crs"
 crs_version: "v3.3.4"
+crs_conf_src_template: "{{ crs_dir }}/crs-setup.conf.example"
 modsec_tmp_dir: "/var/cache/modsecurity"
 modsec_data_dir: "/var/cache/modsecurity"
 modsec_log_dir: "/var/log/mod_security"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ modsec_tmp_dir: "/var/cache/modsecurity"
 modsec_data_dir: "/var/cache/modsecurity"
 modsec_log_dir: "/var/log/mod_security"
 modsec_conf_dir: "/opt/mod_security"
+modsec_conf_src_template: "modsecurity.conf.j2"
 modsec_conf: "{{ modsec_conf_dir }}/modsecurity.conf"
 modsec_unicode_mapping_file: "/opt/mod_security/unicode.mapping"
 test_waf: true

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -13,10 +13,8 @@ platforms:
     image: bwinfosec/centos8-systemd:latest
     privileged: true
     override_command: false
-    dns_servers:
-      - 129.206.100.126
-      - 1.1.1.1
-      - 8.8.8.8
+    networks:
+      - name: molecule_test_network
     tmpfs:
       - /run
       - /run/lock

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -14,6 +14,7 @@ platforms:
     privileged: true
     override_command: false
     dns_servers:
+      - 129.206.100.126
       - 1.1.1.1
       - 8.8.8.8
     tmpfs:

--- a/molecule/debian/molecule.yml
+++ b/molecule/debian/molecule.yml
@@ -13,10 +13,8 @@ platforms:
     image: bwinfosec/debian10-systemd
     privileged: true
     override_command: false
-    dns_servers:
-      - 129.206.100.126
-      - 1.1.1.1
-      - 8.8.8.8
+    networks:
+      - name: molecule_test_network
     tmpfs:
       - /run
       - /run/lock
@@ -29,10 +27,8 @@ platforms:
     image: bwinfosec/debian11-systemd
     privileged: true
     override_command: false
-    dns_servers:
-      - 129.206.100.126
-      - 1.1.1.1
-      - 8.8.8.8
+    networks:
+      - name: molecule_test_network
     tmpfs:
       - /run
       - /run/lock

--- a/molecule/debian/molecule.yml
+++ b/molecule/debian/molecule.yml
@@ -14,6 +14,7 @@ platforms:
     privileged: true
     override_command: false
     dns_servers:
+      - 129.206.100.126
       - 1.1.1.1
       - 8.8.8.8
     tmpfs:
@@ -29,6 +30,7 @@ platforms:
     privileged: true
     override_command: false
     dns_servers:
+      - 129.206.100.126
       - 1.1.1.1
       - 8.8.8.8
     tmpfs:

--- a/molecule/ubuntu/molecule.yml
+++ b/molecule/ubuntu/molecule.yml
@@ -13,10 +13,8 @@ platforms:
     image: bwinfosec/ubuntu1804-systemd
     privileged: true
     override_command: false
-    dns_servers:
-      - 129.206.100.126
-      - 1.1.1.1
-      - 8.8.8.8
+    networks:
+      - name: molecule_test_network
     tmpfs:
       - /run
       - /run/lock
@@ -29,10 +27,8 @@ platforms:
     image: bwinfosec/ubuntu2004-systemd
     privileged: true
     override_command: false
-    dns_servers:
-      - 129.206.100.126
-      - 1.1.1.1
-      - 8.8.8.8
+    networks:
+      - name: molecule_test_network
     tmpfs:
       - /run
       - /run/lock
@@ -45,10 +41,8 @@ platforms:
     image: bwinfosec/ubuntu2204-systemd
     privileged: true
     override_command: false
-    dns_servers:
-      - 129.206.100.126
-      - 1.1.1.1
-      - 8.8.8.8
+    networks:
+      - name: molecule_test_network
     tmpfs:
       - /run
       - /run/lock

--- a/molecule/ubuntu/molecule.yml
+++ b/molecule/ubuntu/molecule.yml
@@ -14,6 +14,7 @@ platforms:
     privileged: true
     override_command: false
     dns_servers:
+      - 129.206.100.126
       - 1.1.1.1
       - 8.8.8.8
     tmpfs:
@@ -29,6 +30,7 @@ platforms:
     privileged: true
     override_command: false
     dns_servers:
+      - 129.206.100.126
       - 1.1.1.1
       - 8.8.8.8
     tmpfs:
@@ -44,6 +46,7 @@ platforms:
     privileged: true
     override_command: false
     dns_servers:
+      - 129.206.100.126
       - 1.1.1.1
       - 8.8.8.8
     tmpfs:

--- a/tasks/install_waf.yml
+++ b/tasks/install_waf.yml
@@ -123,7 +123,7 @@
 
 - name: Create modsecurity config file
   ansible.builtin.template:
-    src: modsecurity.conf.j2
+    src: "{{ modsec_conf_src_template }}"
     dest: "{{ modsec_conf }}"
     mode: 0644
   notify: "Restart service apache2"

--- a/tasks/install_waf.yml
+++ b/tasks/install_waf.yml
@@ -44,13 +44,34 @@
     force: true
   changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
 
-- name: Copy crs-setup.conf.example to crs-setup.conf
+- name: Check if default config is used
+  ansible.builtin.set_fact:
+    crs_default_config_used: "{{ crs_conf_src_template.endswith('/crs-setup.conf.example') }}"
+
+# Derive a default config from the example config. This is only done once if no custom config is used.
+- name: Copy crs-setup.conf.example to crs-setup.conf.default
   ansible.builtin.copy:
     src: "{{ crs_dir }}/crs-setup.conf.example"
-    dest: "{{ crs_dir }}/crs-setup.conf"
+    dest: "{{ crs_dir }}/crs-setup.conf.default"
     mode: '0644'
     remote_src: true
     force: false
+  when: crs_default_config_used
+
+- name: Patch crs-setup.conf.default
+  ansible.builtin.blockinfile:
+    path: "{{ crs_dir }}/crs-setup.conf.default"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    insertafter: "#   setvar:tx.paranoia_level=1"
+    block: |-
+      SecAction \
+        "id:900000,\
+         phase:1,\
+         nolog,\
+         pass,\
+         t:none,\
+         setvar:tx.paranoia_level=1"
+  when: crs_default_config_used
 
 - name: Copy REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example to REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
   ansible.builtin.copy:
@@ -80,19 +101,24 @@
       Include {{ crs_dir }}/rules/*.conf
       IncludeOptional {{ crs_dir }}/plugins/*-after.conf
 
-- name: Patch crs-setup.conf
-  ansible.builtin.blockinfile:
-    path: "{{ crs_dir }}/crs-setup.conf"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK"
-    insertafter: "#   setvar:tx.paranoia_level=1"
-    block: |-
-      SecAction \
-        "id:900000,\
-         phase:1,\
-         nolog,\
-         pass,\
-         t:none,\
-         setvar:tx.paranoia_level=1"
+# Copy either the example config...
+- name: Copy crs-setup.conf.default to crs-setup.conf
+  ansible.builtin.copy:
+    src: "{{ crs_dir }}/crs-setup.conf.default"
+    dest: "{{ crs_dir }}/crs-setup.conf"
+    mode: '0644'
+    remote_src: true
+    force: true
+  when: crs_default_config_used
+
+# ... or template out the custom config.
+- name: Template custom crs-setup.conf to crs-setup.conf
+  ansible.builtin.template:
+    src: "{{ crs_conf_src_template }}"
+    dest: "{{ crs_dir }}/crs-setup.conf"
+    mode: '0644'
+    force: true
+  when: not crs_default_config_used
 
 - name: Set files for redhat
   when: ansible_facts['os_family']|lower == 'redhat'


### PR DESCRIPTION
Proposing two changes:

1. Allow for templating the ModSecurity configuration file (the only way to use an own template was to copy it over the default one)
2. Allow for templating the CRS configuration file. We improved the way a default config is derived from the example config to not have any in-place changes on the final config file.

Side note: If Molecule tests are run from within the university, the DNS server must be an internal one; I included our own DNS in all Molecule configurations...