### PR TITLE
Include configuration files the proper way

### DIFF
--- a/tasks/install_waf.yml
+++ b/tasks/install_waf.yml
@@ -89,17 +89,12 @@
     force: false
     mode: '0644'
 
-- name: Patch apache2 config
-  ansible.builtin.blockinfile:
-    path: "{{ apache_conf }}"
-    insertafter: EOF
-    marker: "# {mark} ANSIBLE MANAGED BLOCK"
-    block: |
-      Include {{ modsec_conf }}
-      Include {{ crs_dir }}/crs-setup.conf
-      IncludeOptional {{ crs_dir }}/plugins/*-before.conf
-      Include {{ crs_dir }}/rules/*.conf
-      IncludeOptional {{ crs_dir }}/plugins/*-after.conf
+- name: Create Apache WAF config
+  ansible.builtin.template:
+    src: "waf.conf.j2"
+    dest: "{{ apache_conf_dir }}/waf.conf"
+    mode: '0644'
+    force: true
 
 # Copy either the example config...
 - name: Copy crs-setup.conf.default to crs-setup.conf

--- a/templates/waf.conf.j2
+++ b/templates/waf.conf.j2
@@ -1,0 +1,5 @@
+Include {{ modsec_conf }}
+Include {{ crs_dir }}/crs-setup.conf
+IncludeOptional {{ crs_dir }}/plugins/*-before.conf
+Include {{ crs_dir }}/rules/*.conf
+IncludeOptional {{ crs_dir }}/plugins/*-after.conf

--- a/vars/centos.yml
+++ b/vars/centos.yml
@@ -5,6 +5,7 @@ packages:
   - httpd
   - mod_security
 apache_conf: "/etc/httpd/conf/httpd.conf"
+apache_conf_dir: "/etc/httpd/conf.d/"
 apache_user: "apache"
 
 waf_service_name: httpd

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -5,6 +5,7 @@ packages:
   - apache2
   - libapache2-mod-security2
 apache_conf: "/etc/apache2/apache2.conf"
+apache_conf_dir: "/etc/apache2/conf-enabled/"
 apache_user: "www-data"
 
 waf_service_name: apache2

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -5,6 +5,7 @@ packages:
   - httpd
   - mod_security
 apache_conf: "/etc/httpd/conf/httpd.conf"
+apache_conf_dir: "/etc/httpd/conf.d/"
 apache_user: "apache"
 
 waf_service_name: httpd

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -5,6 +5,7 @@ packages:
   - apache2
   - libapache2-mod-security2
 apache_conf: "/etc/apache2/apache2.conf"
+apache_conf_dir: "/etc/apache2/conf-enabled/"
 apache_user: "www-data"
 
 waf_service_name: apache2


### PR DESCRIPTION
As dicussed: Put all includes in a central waf configuration file and template it out to a platform-specific include directory.