### PR TITLE
Refactorings and fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 crs_dir: "/opt/owasp_crs"
 crs_version: "v3.3.4"
+crs_conf_dir: "/etc/crs"
 crs_conf_src_template: "{{ crs_dir }}/crs-setup.conf.example"
 modsec_tmp_dir: "/var/cache/modsecurity"
 modsec_data_dir: "/var/cache/modsecurity"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,15 @@
   ansible.builtin.service:
     name: "{{ waf_service_name }}"
     state: restarted
+
+- name: Warn about compatibility hack
+  ansible.builtin.debug:
+    msg: >
+      CAUTION! Running ModSecurity v{{ modsecurity_version }} with Core Rule Set {{ crs_version }}.
+      CRS {{ crs_version }} contains a critical fix for CVE-2022-39956 that is incompatible
+      with ModSecurity v{{ modsecurity_version }}.
+      As a workaround, rule 'REQUEST-922-MULTIPART-ATTACK.conf' has been removed to ensure compatibility.
+      We strongly advise updating your ModSecurity installation to 2.9.6 or higher,
+      or to downgrade your CRS to a version that does not include this fix (not recommended).
+      See CVE https://nvd.nist.gov/vuln/detail/CVE-2022-39956 for more details.
+  changed_when: true

--- a/tasks/install_waf.yml
+++ b/tasks/install_waf.yml
@@ -19,71 +19,31 @@
     - "{{ modsec_log_dir }}"
     - "{{ modsec_data_dir }}"
 
-- name: Fetch coreruleset
+- name: Fetch OWASP Core Rule Set (CRS)
   ansible.builtin.git:
     repo: 'https://github.com/coreruleset/coreruleset.git'
     dest: "{{ crs_dir }}"
     version: "{{ crs_version }}"
     force: true
-  changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
+  changed_when: "result.changed and not ('molecule-idempotence-notest' in ansible_skip_tags)"
+  register: result
 
-- name: Check if default config is used
-  ansible.builtin.set_fact:
-    crs_default_config_used: "{{ crs_conf_src_template.endswith('/crs-setup.conf.example') }}"
-
-# Derive a default config from the example config. This is only done once if no custom config is used.
-- name: Copy crs-setup.conf.example to crs-setup.conf.default
-  ansible.builtin.copy:
-    src: "{{ crs_dir }}/crs-setup.conf.example"
-    dest: "{{ crs_dir }}/crs-setup.conf.default"
-    mode: '0644'
-    remote_src: true
-    force: false
-  when: crs_default_config_used
-
-- name: Patch crs-setup.conf.default
-  ansible.builtin.blockinfile:
-    path: "{{ crs_dir }}/crs-setup.conf.default"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK"
-    insertafter: "#   setvar:tx.paranoia_level=1"
-    block: |-
-      SecAction \
-        "id:900000,\
-         phase:1,\
-         nolog,\
-         pass,\
-         t:none,\
-         setvar:tx.paranoia_level=1"
-  when: crs_default_config_used
-
-- name: Copy REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example to REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
-  ansible.builtin.copy:
-    remote_src: true
-    src: "{{ crs_dir }}/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example"
-    dest: "{{ crs_dir }}/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf"
-    force: false
-    mode: '0644'
-
-- name: Copy RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example to RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
-  ansible.builtin.copy:
-    remote_src: true
-    src: "{{ crs_dir }}/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example"
-    dest: "{{ crs_dir }}/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf"
-    force: false
-    mode: '0644'
-
-- name: Create Apache WAF config
+- name: Create Apache WAF configuration
   ansible.builtin.template:
     src: "waf.conf.j2"
     dest: "{{ apache_conf_dir }}/waf.conf"
     mode: '0644'
     force: true
 
+- name: Check if default config is used
+  ansible.builtin.set_fact:
+    crs_default_config_used: "{{ crs_conf_src_template.endswith('/crs-setup.conf.example') }}"
+
 # Copy either the example config...
-- name: Copy crs-setup.conf.default to crs-setup.conf
+- name: Copy crs-setup.conf.example to crs-setup.conf
   ansible.builtin.copy:
-    src: "{{ crs_dir }}/crs-setup.conf.default"
-    dest: "{{ crs_dir }}/crs-setup.conf"
+    src: "{{ crs_dir }}/crs-setup.conf.example"
+    dest: "{{ crs_conf_dir }}/crs-setup.conf"
     mode: '0644'
     remote_src: true
     force: true
@@ -93,7 +53,7 @@
 - name: Template custom crs-setup.conf to crs-setup.conf
   ansible.builtin.template:
     src: "{{ crs_conf_src_template }}"
-    dest: "{{ crs_dir }}/crs-setup.conf"
+    dest: "{{ crs_conf_dir }}/crs-setup.conf"
     mode: '0644'
     force: true
   when: not crs_default_config_used
@@ -144,7 +104,8 @@
     path: "{{ crs_dir }}/rules/REQUEST-922-MULTIPART-ATTACK.conf"
     state: absent
   when: "crs_version == 'v3.3.4'"
-  changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
+  changed_when: "result.changed and 'molecule-idempotence-notest' not in ansible_skip_tags"
+  register: result
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/tasks/install_waf.yml
+++ b/tasks/install_waf.yml
@@ -1,9 +1,18 @@
 ---
-- name: Install packages {{ packages|join(', ') }}
+- name: Install packages {{ packages | join(', ') }}
   ansible.builtin.package:
     name: "{{ packages }}"
     state: present
     update_cache: true
+
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
+    strategy: first
+
+- name: Set ModSecurity lib version
+  ansible.builtin.set_fact:
+    modsecurity_version: "{{ ansible_facts.packages[lib_modsecurity][0]['version'] }}"
 
 - name: Create directories
   ansible.builtin.file:
@@ -24,6 +33,7 @@
     repo: 'https://github.com/coreruleset/coreruleset.git'
     dest: "{{ crs_dir }}"
     version: "{{ crs_version }}"
+    depth: 1
     force: true
   changed_when: "result.changed and not ('molecule-idempotence-notest' in ansible_skip_tags)"
   register: result
@@ -99,13 +109,14 @@
     mode: 0644
   notify: "Restart service apache2"
 
-- name: Remove error prone rule
+- name: Ensure ModSecurity / CRS compatibility
   ansible.builtin.file:
     path: "{{ crs_dir }}/rules/REQUEST-922-MULTIPART-ATTACK.conf"
     state: absent
-  when: "crs_version == 'v3.3.4'"
+  when: "modsecurity_version is version('2.9.6', '<')"
   changed_when: "result.changed and 'molecule-idempotence-notest' not in ansible_skip_tags"
   register: result
+  notify: Warn about compatibility hack
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/tasks/install_waf.yml
+++ b/tasks/install_waf.yml
@@ -28,6 +28,21 @@
     - "{{ modsec_log_dir }}"
     - "{{ modsec_data_dir }}"
 
+- name: Create configuration files
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: 0644
+    force: true
+  notify: "Restart service apache2"
+  with_items:
+    - { src: "waf.conf.j2",
+        dest: "{{ apache_conf_dir }}/waf.conf" }
+    - { src: "unicode.mapping",
+        dest: "{{ modsec_unicode_mapping_file }}" }
+    - { src: "{{ modsec_conf_src_template }}",
+        dest: "{{ modsec_conf }}" }
+
 - name: Fetch OWASP Core Rule Set (CRS)
   ansible.builtin.git:
     repo: 'https://github.com/coreruleset/coreruleset.git'
@@ -37,13 +52,6 @@
     force: true
   changed_when: "result.changed and not ('molecule-idempotence-notest' in ansible_skip_tags)"
   register: result
-
-- name: Create Apache WAF configuration
-  ansible.builtin.template:
-    src: "waf.conf.j2"
-    dest: "{{ apache_conf_dir }}/waf.conf"
-    mode: '0644'
-    force: true
 
 - name: Check if default config is used
   ansible.builtin.set_fact:
@@ -94,20 +102,6 @@
       ansible.builtin.file:
         path: /etc/apache2/mods-enabled/security2.conf
         state: absent
-
-- name: Create modsecurity config file
-  ansible.builtin.template:
-    src: "{{ modsec_conf_src_template }}"
-    dest: "{{ modsec_conf }}"
-    mode: 0644
-  notify: "Restart service apache2"
-
-- name: Create unicode mapping file
-  ansible.builtin.template:
-    src: unicode.mapping
-    dest: "{{ modsec_unicode_mapping_file }}"
-    mode: 0644
-  notify: "Restart service apache2"
 
 - name: Ensure ModSecurity / CRS compatibility
   ansible.builtin.file:

--- a/tasks/install_waf.yml
+++ b/tasks/install_waf.yml
@@ -1,40 +1,23 @@
 ---
-- name: Install packages
+- name: Install packages {{ packages|join(', ') }}
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: "{{ packages }}"
     state: present
     update_cache: true
-  with_items: "{{ packages }}"
 
-- name: Create modsecurity conf dir
+- name: Create directories
   ansible.builtin.file:
-    path: "{{ modsec_conf_dir }}"
-    state: directory
-    owner: "{{ apache_user }}"
-    mode: "0700"
-
-- name: Create modsecurity tmp dir
-  ansible.builtin.file:
-    path: "{{ modsec_tmp_dir }}"
-    state: directory
+    path: "{{ item }}"
     owner: "{{ apache_user }}"
     group: "{{ apache_user }}"
-    mode: "0700"
-
-- name: Create modsecurity log dir
-  ansible.builtin.file:
-    path: "{{ modsec_log_dir }}"
     state: directory
-    owner: "{{ apache_user }}"
     mode: "0700"
-
-- name: Create modsecurity data dir
-  ansible.builtin.file:
-    path: "{{ modsec_data_dir }}"
-    state: directory
-    owner: "{{ apache_user }}"
-    group: "{{ apache_user }}"
-    mode: "0700"
+  with_items:
+    - "{{ crs_conf_dir }}"
+    - "{{ modsec_conf_dir }}"
+    - "{{ modsec_tmp_dir }}"
+    - "{{ modsec_log_dir }}"
+    - "{{ modsec_data_dir }}"
 
 - name: Fetch coreruleset
   ansible.builtin.git:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Include vars
+- name: Include platform-specific variables
   ansible.builtin.include_vars:
     file: "{{ ansible_distribution | lower }}.yml"
 

--- a/templates/waf.conf.j2
+++ b/templates/waf.conf.j2
@@ -1,5 +1,5 @@
 Include {{ modsec_conf }}
-Include {{ crs_dir }}/crs-setup.conf
+Include {{ crs_conf_dir }}/crs-setup.conf
 IncludeOptional {{ crs_dir }}/plugins/*-before.conf
 Include {{ crs_dir }}/rules/*.conf
 IncludeOptional {{ crs_dir }}/plugins/*-after.conf

--- a/vars/centos.yml
+++ b/vars/centos.yml
@@ -7,7 +7,7 @@ packages:
   - "{{ lib_modsecurity }}"
 
 apache_conf: "/etc/httpd/conf/httpd.conf"
-apache_conf_dir: "/etc/httpd/conf.d/"
+apache_conf_dir: "/etc/httpd/conf.d"
 apache_user: "apache"
 
 waf_service_name: httpd

--- a/vars/centos.yml
+++ b/vars/centos.yml
@@ -1,9 +1,11 @@
 ---
+lib_modsecurity: mod_security
 packages:
   - git
   - curl
   - httpd
-  - mod_security
+  - "{{ lib_modsecurity }}"
+
 apache_conf: "/etc/httpd/conf/httpd.conf"
 apache_conf_dir: "/etc/httpd/conf.d/"
 apache_user: "apache"

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,9 +1,11 @@
 ---
+lib_modsecurity: "libapache2-mod-security2"
 packages:
   - git
   - curl
   - apache2
-  - libapache2-mod-security2
+  - "{{ lib_modsecurity }}"
+
 apache_conf: "/etc/apache2/apache2.conf"
 apache_conf_dir: "/etc/apache2/conf-enabled/"
 apache_user: "www-data"

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -7,7 +7,7 @@ packages:
   - "{{ lib_modsecurity }}"
 
 apache_conf: "/etc/apache2/apache2.conf"
-apache_conf_dir: "/etc/apache2/conf-enabled/"
+apache_conf_dir: "/etc/apache2/conf-enabled"
 apache_user: "www-data"
 
 waf_service_name: apache2

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -7,7 +7,7 @@ packages:
   - "{{ lib_modsecurity }}"
 
 apache_conf: "/etc/httpd/conf/httpd.conf"
-apache_conf_dir: "/etc/httpd/conf.d/"
+apache_conf_dir: "/etc/httpd/conf.d"
 apache_user: "apache"
 
 waf_service_name: httpd

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,9 +1,11 @@
 ---
+lib_modsecurity: mod_security
 packages:
   - git
   - curl
   - httpd
-  - mod_security
+  - "{{ lib_modsecurity }}"
+
 apache_conf: "/etc/httpd/conf/httpd.conf"
 apache_conf_dir: "/etc/httpd/conf.d/"
 apache_user: "apache"

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -1,9 +1,11 @@
 ---
+lib_modsecurity: "libapache2-mod-security2"
 packages:
   - git
   - curl
   - apache2
-  - libapache2-mod-security2
+  - "{{ lib_modsecurity }}"
+
 apache_conf: "/etc/apache2/apache2.conf"
 apache_conf_dir: "/etc/apache2/conf-enabled/"
 apache_user: "www-data"

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -7,7 +7,7 @@ packages:
   - "{{ lib_modsecurity }}"
 
 apache_conf: "/etc/apache2/apache2.conf"
-apache_conf_dir: "/etc/apache2/conf-enabled/"
+apache_conf_dir: "/etc/apache2/conf-enabled"
 apache_user: "www-data"
 
 waf_service_name: apache2


### PR DESCRIPTION
We want to contribute some changes to the waf-role:

- Clearly state why we remove the "error prone rule" and improve the way the incompatibility is determined (by looking at the ModSecurity version installed); mention the [CVE that caused the breaking change](https://nvd.nist.gov/vuln/detail/CVE-2022-39956)
- Refactor similar tasks towards loops
- Remove useless patching of the `crs-setup.example.conf` when using it as a default (the paranoia level is already 1 by default)
- Do not copy `REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example` and `RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example`; we already have the `plugins/` infrastructure for custom rules and we do not want to encourage manual editing of these files
- Improve the conditional skipping of tasks in Molecule tests so the task do not wrongly report a change even when there were no changes 